### PR TITLE
recreate ability to init_app

### DIFF
--- a/flaskr/db.py
+++ b/flaskr/db.py
@@ -41,8 +41,6 @@ def print_hello():
     print('hello')
 
 
-app.cli.add_command(print_hello)
-
 # @click.command(name='init-db')
 # @with_appcontext
 # def init_db_command():
@@ -51,8 +49,9 @@ app.cli.add_command(print_hello)
 #     click.echo('Initialized the database.')
 
 
-# def init_app(app):
-#     app.teardown_appcontext(close_db)
-#     app.cli.add_command(init_db_command)
+def init_app(app):
+    app.teardown_appcontext(close_db)
+    app.cli.add_command(print_hello)
+    # app.cli.add_command(init_db_command)
 
 


### PR DESCRIPTION
init_app is used in your `__init__.py` code, it's job is to say 'Hey, can you please register these commands against the app object`

So in your __init__.py code you're doing:

```
from . import db
    db.init_app(app)
```

So that `init_app` function is getting a copy of the Flask app instance, then registers your cli commands onto it-- so you'll be able to see them when running `flask` on the terminal.